### PR TITLE
build(gradle): update archivesName setting to use project.getArchivesName()

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,7 +54,7 @@ allprojects {
     }
     apply<BasePlugin>()
     base {
-        archivesName.set("${rootProject.name}-${project.name}")
+        archivesName.set(project.getArchivesName())
     }
 }
 


### PR DESCRIPTION
- Replace hardcoded archivesName with dynamic value from project.getArchivesName()
- Improve flexibility and maintainability of build configuration