### PR TITLE
build: use project name instead of archives name

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,7 +48,7 @@ allprojects {
     }
     tasks.withType<Jar> {
         manifest {
-            attributes["Implementation-Title"] = project.name
+            attributes["Implementation-Title"] = project.getArchivesName()
             attributes["Implementation-Version"] = project.version
         }
     }


### PR DESCRIPTION
- Changed the attribute 'Implementation-Title' from project.name to project.getArchivesName()
- This change ensures consistency in how the project title is represented in the JAR manifest