### PR TITLE
build(deps): add kotlin-logging dependency

### DIFF
--- a/dependencies/build.gradle.kts
+++ b/dependencies/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
     api(platform(libs.simba.bom))
     constraints {
         api(libs.guava)
+        api(libs.kotlin.logging)
         api(libs.swagger.annotations)
         api(libs.hamcrest)
         api(libs.mockk)

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -6,6 +6,7 @@ dependencies {
     ksp(platform(project(":dependencies")))
     api(project(":api"))
     api("me.ahoo.wow:wow-spring")
+    api("io.github.oshai:kotlin-logging-jvm")
     ksp("me.ahoo.wow:wow-compiler")
     testImplementation("me.ahoo.wow:wow-test")
     testImplementation("io.projectreactor:reactor-test")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ cosec = "2.12.8"
 cosky = "4.8.0"
 simba = "2.8.1"
 guava = "33.4.5-jre"
+kotlin-logging = "7.0.5"
 swagger = "2.2.29"
 hamcrest = "3.0"
 mockk = "1.13.17"
@@ -33,6 +34,7 @@ cosec-bom = { module = "me.ahoo.cosec:cosec-bom", version.ref = "cosec" }
 cosky-bom = { module = "me.ahoo.cosky:cosky-bom", version.ref = "cosky" }
 simba-bom = { module = "me.ahoo.simba:simba-bom", version.ref = "simba" }
 guava = { module = "com.google.guava:guava", version.ref = "guava" }
+kotlin-logging = { module = "io.github.oshai:kotlin-logging-jvm", version.ref = "kotlin-logging" }
 swagger-annotations = { module = "io.swagger.core.v3:swagger-annotations", version.ref = "swagger" }
 springdoc-openapi-starter-webflux-ui = { module = "org.springdoc:springdoc-openapi-starter-webflux-ui", version.ref = "springdoc" }
 hamcrest = { module = "org.hamcrest:hamcrest", version.ref = "hamcrest" }


### PR DESCRIPTION
- Add kotlin-logging to dependencies/build.gradle.kts
- Include kotlin-logging-jvm in domain/build.gradle.kts
- Update gradle/libs.versions.toml with kotlin-logging version 7.0.5