### PR TITLE
test: replace Hamcrest with AssertJ for unit testing

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -117,7 +117,7 @@ configure(libraryProjects) {
         detektPlugins(dependenciesProject)
         implementation("com.google.guava:guava")
         implementation("org.slf4j:slf4j-api")
-        testImplementation("org.hamcrest:hamcrest")
+        testImplementation("org.assertj:assertj-core")
         testImplementation("io.mockk:mockk") {
             exclude(group = "org.slf4j", module = "slf4j-api")
         }

--- a/dependencies/build.gradle.kts
+++ b/dependencies/build.gradle.kts
@@ -20,11 +20,11 @@ dependencies {
     api(platform(libs.cosec.bom))
     api(platform(libs.cosky.bom))
     api(platform(libs.simba.bom))
+    api(platform(libs.assertj.bom))
     constraints {
         api(libs.guava)
         api(libs.kotlin.logging)
         api(libs.swagger.annotations)
-        api(libs.hamcrest)
         api(libs.mockk)
         api(libs.detekt.formatting)
     }

--- a/domain/src/test/kotlin/me/ahoo/wow/template/domain/demo/DemoSagaTest.kt
+++ b/domain/src/test/kotlin/me/ahoo/wow/template/domain/demo/DemoSagaTest.kt
@@ -3,8 +3,7 @@ package me.ahoo.wow.template.domain.demo
 import me.ahoo.wow.template.api.demo.DemoCreated
 import me.ahoo.wow.template.api.demo.UpdateDemo
 import me.ahoo.wow.test.SagaVerifier.sagaVerifier
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.equalTo
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class DemoSagaTest {
@@ -13,11 +12,9 @@ class DemoSagaTest {
     fun onCreated() {
         val event = DemoCreated("data")
         sagaVerifier<DemoSaga>()
-            .`when`(
-                event
-            )
+            .whenEvent(event)
             .expectCommandBody<UpdateDemo> {
-                assertThat(it.data, equalTo("updated"))
+                assertThat(it.data).isEqualTo("updated")
             }
             .verify()
     }

--- a/domain/src/test/kotlin/me/ahoo/wow/template/domain/demo/DemoTest.kt
+++ b/domain/src/test/kotlin/me/ahoo/wow/template/domain/demo/DemoTest.kt
@@ -1,14 +1,13 @@
 package me.ahoo.wow.template.domain.demo
 
-import me.ahoo.wow.id.GlobalIdGenerator
+import me.ahoo.wow.id.generateGlobalId
 import me.ahoo.wow.template.api.demo.CreateDemo
 import me.ahoo.wow.template.api.demo.DemoCreated
 import me.ahoo.wow.template.api.demo.DemoUpdated
 import me.ahoo.wow.template.api.demo.UpdateDemo
-import me.ahoo.wow.test.aggregate.`when`
+import me.ahoo.wow.test.aggregate.whenCommand
 import me.ahoo.wow.test.aggregateVerifier
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.equalTo
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class DemoTest {
@@ -20,11 +19,11 @@ class DemoTest {
         )
 
         aggregateVerifier<Demo, DemoState>()
-            .`when`(command)
+            .whenCommand(command)
             .expectNoError()
             .expectEventType(DemoCreated::class.java)
             .expectState {
-                assertThat(it.data, equalTo(command.data))
+                assertThat(it.data).isEqualTo(command.data)
             }
             .verify()
     }
@@ -32,17 +31,17 @@ class DemoTest {
     @Test
     fun onUpdate() {
         val command = UpdateDemo(
-            id = GlobalIdGenerator.generateAsString(),
+            id = generateGlobalId(),
             data = "data"
         )
 
         aggregateVerifier<Demo, DemoState>()
             .given(DemoCreated("old"))
-            .`when`(command)
+            .whenCommand(command)
             .expectNoError()
             .expectEventType(DemoUpdated::class.java)
             .expectState {
-                assertThat(it.data, equalTo(command.data))
+                assertThat(it.data).isEqualTo(command.data)
             }
             .verify()
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,10 +11,10 @@ simba = "2.8.6"
 guava = "33.4.8-jre"
 kotlin-logging = "7.0.6"
 swagger = "2.2.30"
-hamcrest = "3.0"
+springdoc = "2.8.6"
+assertj = "3.27.3"
 mockk = "1.14.0"
 detekt-formatting = "1.23.8"
-springdoc = "2.8.6"
 # plugins
 detekt = "1.23.8"
 dokka = "2.0.0"
@@ -37,7 +37,7 @@ guava = { module = "com.google.guava:guava", version.ref = "guava" }
 kotlin-logging = { module = "io.github.oshai:kotlin-logging-jvm", version.ref = "kotlin-logging" }
 swagger-annotations = { module = "io.swagger.core.v3:swagger-annotations", version.ref = "swagger" }
 springdoc-openapi-starter-webflux-ui = { module = "org.springdoc:springdoc-openapi-starter-webflux-ui", version.ref = "springdoc" }
-hamcrest = { module = "org.hamcrest:hamcrest", version.ref = "hamcrest" }
+assertj-bom = { module = "org.assertj:assertj-bom", version.ref = "assertj" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt-formatting" }
 


### PR DESCRIPTION
- Remove Hamcrest dependency from build.gradle.kts
- Add AssertJ dependency to dependencies/build.gradle.kts and gradle/libs.versions.toml
- Update test files to use AssertJ instead of Hamcrest for assertions
- Refactor test code to use more idiomatic AssertJ syntax