### PR TITLE
build(deps): replace assertj with fluent-assert

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -117,7 +117,7 @@ configure(libraryProjects) {
         detektPlugins(dependenciesProject)
         implementation("com.google.guava:guava")
         implementation("org.slf4j:slf4j-api")
-        testImplementation("org.assertj:assertj-core")
+        testImplementation("me.ahoo.test:fluent-assert-core")
         testImplementation("io.mockk:mockk") {
             exclude(group = "org.slf4j", module = "slf4j-api")
         }

--- a/dependencies/build.gradle.kts
+++ b/dependencies/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
     api(platform(libs.cosec.bom))
     api(platform(libs.cosky.bom))
     api(platform(libs.simba.bom))
-    api(platform(libs.assertj.bom))
+    api(platform(libs.fluent.assert.bom))
     constraints {
         api(libs.guava)
         api(libs.kotlin.logging)

--- a/domain/src/test/kotlin/me/ahoo/wow/template/domain/demo/DemoSagaTest.kt
+++ b/domain/src/test/kotlin/me/ahoo/wow/template/domain/demo/DemoSagaTest.kt
@@ -1,9 +1,9 @@
 package me.ahoo.wow.template.domain.demo
 
+import me.ahoo.test.asserts.assert
 import me.ahoo.wow.template.api.demo.DemoCreated
 import me.ahoo.wow.template.api.demo.UpdateDemo
 import me.ahoo.wow.test.SagaVerifier.sagaVerifier
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class DemoSagaTest {
@@ -14,7 +14,7 @@ class DemoSagaTest {
         sagaVerifier<DemoSaga>()
             .whenEvent(event)
             .expectCommandBody<UpdateDemo> {
-                assertThat(it.data).isEqualTo("updated")
+                it.data.assert().isEqualTo("updated")
             }
             .verify()
     }

--- a/domain/src/test/kotlin/me/ahoo/wow/template/domain/demo/DemoTest.kt
+++ b/domain/src/test/kotlin/me/ahoo/wow/template/domain/demo/DemoTest.kt
@@ -1,5 +1,6 @@
 package me.ahoo.wow.template.domain.demo
 
+import me.ahoo.test.asserts.assert
 import me.ahoo.wow.id.generateGlobalId
 import me.ahoo.wow.template.api.demo.CreateDemo
 import me.ahoo.wow.template.api.demo.DemoCreated
@@ -7,7 +8,6 @@ import me.ahoo.wow.template.api.demo.DemoUpdated
 import me.ahoo.wow.template.api.demo.UpdateDemo
 import me.ahoo.wow.test.aggregate.whenCommand
 import me.ahoo.wow.test.aggregateVerifier
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class DemoTest {
@@ -23,7 +23,7 @@ class DemoTest {
             .expectNoError()
             .expectEventType(DemoCreated::class.java)
             .expectState {
-                assertThat(it.data).isEqualTo(command.data)
+                it.data.assert().isEqualTo(command.data)
             }
             .verify()
     }
@@ -41,7 +41,7 @@ class DemoTest {
             .expectNoError()
             .expectEventType(DemoUpdated::class.java)
             .expectState {
-                assertThat(it.data).isEqualTo(command.data)
+                it.data.assert().isEqualTo(command.data)
             }
             .verify()
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ guava = "33.4.8-jre"
 kotlin-logging = "7.0.7"
 swagger = "2.2.30"
 springdoc = "2.8.6"
-assertj = "3.27.3"
+fluent-assert = "0.0.3"
 mockk = "1.14.0"
 detekt-formatting = "1.23.8"
 # plugins
@@ -37,7 +37,7 @@ guava = { module = "com.google.guava:guava", version.ref = "guava" }
 kotlin-logging = { module = "io.github.oshai:kotlin-logging-jvm", version.ref = "kotlin-logging" }
 swagger-annotations = { module = "io.swagger.core.v3:swagger-annotations", version.ref = "swagger" }
 springdoc-openapi-starter-webflux-ui = { module = "org.springdoc:springdoc-openapi-starter-webflux-ui", version.ref = "springdoc" }
-assertj-bom = { module = "org.assertj:assertj-bom", version.ref = "assertj" }
+fluent-assert-bom = { module = "me.ahoo.test:fluent-assert-bom", version.ref = "fluent-assert" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt-formatting" }
 


### PR DESCRIPTION
- Update build.gradle.kts to use fluent-assert instead of assertj
- Update dependencies/build.gradle.kts to add fluent-assert platform
- Update gradle/libs.versions.toml to define fluent-assert version
- Modify test files to use fluent-assert instead of assertj

