### PR TITLE
Update Logging and Annotations in DemoSaga and DemoProjector

### DIFF
--- a/domain/src/main/kotlin/me/ahoo/wow/template/domain/demo/DemoSaga.kt
+++ b/domain/src/main/kotlin/me/ahoo/wow/template/domain/demo/DemoSaga.kt
@@ -1,22 +1,21 @@
 package me.ahoo.wow.template.domain.demo
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import me.ahoo.wow.api.annotation.OnEvent
 import me.ahoo.wow.api.modeling.AggregateId
-import me.ahoo.wow.spring.stereotype.StatelessSaga
+import me.ahoo.wow.spring.stereotype.StatelessSagaComponent
 import me.ahoo.wow.template.api.demo.DemoCreated
 import me.ahoo.wow.template.api.demo.UpdateDemo
 
-@StatelessSaga
+@StatelessSagaComponent
 class DemoSaga {
     companion object {
-        private val log = org.slf4j.LoggerFactory.getLogger(DemoSaga::class.java)
+        private val log = KotlinLogging.logger { }
     }
 
     @OnEvent
     fun onCreated(event: DemoCreated, aggregateId: AggregateId): UpdateDemo {
-        if (log.isDebugEnabled) {
-            log.debug("onCreated: $event")
-        }
+        log.debug { "onCreated: $event" }
         return UpdateDemo(
             id = aggregateId.id,
             data = "updated"

--- a/server/src/main/kotlin/me/ahoo/wow/template/server/demo/DemoProjector.kt
+++ b/server/src/main/kotlin/me/ahoo/wow/template/server/demo/DemoProjector.kt
@@ -1,18 +1,16 @@
 package me.ahoo.wow.template.server.demo
 
-import me.ahoo.wow.spring.stereotype.ProjectionProcessor
+import io.github.oshai.kotlinlogging.KotlinLogging
+import me.ahoo.wow.spring.stereotype.ProjectionProcessorComponent
 import me.ahoo.wow.template.api.demo.DemoCreated
-import org.slf4j.LoggerFactory
 
-@ProjectionProcessor
+@ProjectionProcessorComponent
 class DemoProjector {
     companion object {
-        private val log = LoggerFactory.getLogger(DemoProjector::class.java)
+        private val log = KotlinLogging.logger {  }
     }
 
     fun onEvent(event: DemoCreated) {
-        if (log.isDebugEnabled) {
-            log.debug("onEvent: $event")
-        }
+        log.debug { "onEvent: $event" }
     }
 }


### PR DESCRIPTION
Changes proposed in this pull request:
- Refactor the logging mechanism to use KotlinLogging.
- Update annotations to `StatelessSagaComponent` and `ProjectionProcessorComponent` for better alignment with the framework's conventions.