### PR TITLE
build(deps): update dependency management for springdoc

### DIFF
--- a/dependencies/build.gradle.kts
+++ b/dependencies/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
     api(platform(libs.cosec.bom))
     api(platform(libs.cosky.bom))
     api(platform(libs.simba.bom))
+    api(platform(libs.springdoc.bom))
     api(platform(libs.fluent.assert.bom))
     constraints {
         api(libs.guava)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,7 +36,7 @@ simba-bom = { module = "me.ahoo.simba:simba-bom", version.ref = "simba" }
 guava = { module = "com.google.guava:guava", version.ref = "guava" }
 kotlin-logging = { module = "io.github.oshai:kotlin-logging-jvm", version.ref = "kotlin-logging" }
 swagger-annotations = { module = "io.swagger.core.v3:swagger-annotations", version.ref = "swagger" }
-springdoc-openapi-starter-webflux-ui = { module = "org.springdoc:springdoc-openapi-starter-webflux-ui", version.ref = "springdoc" }
+springdoc-bom = { module = "org.springdoc:springdoc-openapi-bom", version.ref = "springdoc" }
 fluent-assert-bom = { module = "me.ahoo.test:fluent-assert-bom", version.ref = "fluent-assert" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt-formatting" }


### PR DESCRIPTION
- Add springdoc-bom to the list of platform dependencies
- Replace springdoc-openapi-starter-webflux-ui with springdoc-bom in libs.versions.toml
- This change centralizes springdoc version management using a bill of materials (BOM)

