### PR TITLE
build(server): comment out cosec-openapi dependency

### DIFF
--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -67,6 +67,7 @@ dependencies {
 //    implementation("me.ahoo.cosid:cosid-spring-redis")
 //    implementation("org.springframework.boot:spring-boot-starter-data-redis-reactive")
     implementation("me.ahoo.cosid:cosid-spring-boot-starter")
+//    implementation("me.ahoo.cosec:cosec-openapi")
 //    implementation("me.ahoo.cosec:cosec-webflux")
 //    implementation("me.ahoo.cosec:cosec-spring-boot-starter")
 //    implementation("me.ahoo.cosky:cosky-spring-cloud-starter-discovery")


### PR DESCRIPTION
- Remove cosec-openapi implementation from build.gradle.kts
- This change simplifies the project's dependencies


