### PR TITLE
build(server): remove wow-mock dependency

### DIFF
--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -55,7 +55,6 @@ dependencies {
 //    implementation("me.ahoo.wow:wow-kafka")
 //    implementation("me.ahoo.wow:wow-mongo")
 //    implementation("me.ahoo.wow:wow-elasticsearch")
-    implementation("me.ahoo.wow:wow-mock")
     implementation("me.ahoo.wow:wow-opentelemetry")
     implementation("me.ahoo.wow:wow-webflux")
     implementation("me.ahoo.wow:wow-cosec")


### PR DESCRIPTION
- Remove implementation of "me.ahoo.wow:wow-mock" from build.gradle.kts
