### PR TITLE
build: update ksp plugin version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@ fluent-assert = "0.2.0"
 mockk = "1.14.4"
 # plugins
 kotlin = "2.2.0"
-ksp = "2.1.21-2.0.2"
+ksp = "2.2.0-2.0.2"
 dokka = "2.0.0"
 detekt = "1.23.8"
 publish-plugin = "2.0.0"


### PR DESCRIPTION
- Update ksp version from 2.1.21-2.0.2 to 2.2.0-2.0.2
- This change aligns the ksp plugin version with the updated kotlin version
