### PR TITLE
build: simplify import configuration in detekt.yml

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -25,9 +25,6 @@ style:
   WildcardImport:
     excludeImports:
       - java.util.*
-      - org.hamcrest.Matchers.*
-      - org.hamcrest.MatcherAssert.*
-      - org.junit.jupiter.api.Assertions.*
 naming:
   MemberNameEqualsClassName:
     active: false
@@ -43,7 +40,7 @@ performance:
     active: false
 formatting:
   NoWildcardImports:
-    packagesToUseImportOnDemandProperty: "java.util.*,org.hamcrest.Matchers.*,org.hamcrest.MatcherAssert.*,org.junit.jupiter.api.Assertions.*"
+    packagesToUseImportOnDemandProperty: "java.util.*"
   MaximumLineLength:
     active: false
   Filename:


### PR DESCRIPTION
- Remove specific package exclusions for WildcardImport rule
- Update packagesToUseImportOnDemandProperty to only include java.util.*
- Delete redundant indentation in the configuration file

