### PR TITLE
refactor(client): rename package and update metadata

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,25 +1,22 @@
 {
-  "name": "@ahoo-wang/demo-service",
+  "name": "@ahoo-wang/wow-client",
   "version": "0.0.1",
-  "description": "Integration Test Fetcher",
+  "description": "WOW Project Client",
   "keywords": [
-    "fetcher",
-    "http",
+    "wow",
     "client",
-    "examples",
-    "sse",
-    "server-sent-events"
+    "typescript"
   ],
   "author": "Ahoo-Wang",
   "license": "Apache-2.0",
-  "homepage": "https://github.com/Ahoo-Wang/fetcher/tree/master/examples",
+  "homepage": "https://github.com/Ahoo-Wang/wow-project-template",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Ahoo-Wang/fetcher.git",
-    "directory": "integration-test"
+    "url": "https://github.com/Ahoo-Wang/wow-project-template.git",
+    "directory": "client"
   },
   "bugs": {
-    "url": "https://github.com/Ahoo-Wang/fetcher/issues"
+    "url": "https://github.com/Ahoo-Wang/wow-project-template/issues"
   },
   "type": "module",
   "main": "./dist/index.umd.js",


### PR DESCRIPTION
- Changed package name from @ahoo-wang/demo-service to @ahoo-wang/wow-client
- Updated description to WOW Project Client
- Removed fetcher, http, examples, sse, and server-sent-events keywords
- Added wow and typescript keywords
- Updated homepage URL to wow-project-template repository
- Changed repository URL and directory to wow-project-template/client
- Updated bugs URL to wow-project-template issues tracker

