### PR TITLE
chore(renovate): enable recreateClosed for major upgrades

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,7 @@
   "commitMessageTopic": "{{depName}}",
   "gitAuthor": "Ahoo Wang <4384159+Ahoo-Wang@users.noreply.github.com>",
   "rangeStrategy": "bump",
+  "recreateClosed": true,
   "lockFileMaintenance": { "enabled": false },
   "prHourlyLimit": 10,
   "prConcurrentLimit": 10,


### PR DESCRIPTION
## Why

依赖更新 CI 跑得正常,但两个 major 升级 PR 被关闭后不再重建:

- #1054 dragonwell Docker tag → v25
- #1055 eslint → v10

根因是 Renovate 默认 `recreateClosed: false`,检测到同标题的已关闭记录即跳过(分支已被删除)。开启 `recreateClosed: true` 后,下次运行会重新评估这两个升级并重建 PR。

## 验证

- [x] `renovate.json` 配置项已添加
- [ ] 合入后下次 Renovate 运行重建 #1054 / #1055
- [ ] 重建后需人工验证 CI(破坏性升级)

## 附带说明

- **#1071 wow-bom 8.9.1** 已由今日手动触发创建,与本 PR 无关
- **3 个 `invalid-version`** 是 workflow 里 `runs-on: ubuntu-latest` 的 GitHub Runner,Renovate 正常跳过 `*-latest`,非 bug,不处理