### PR TITLE
fix(deps) Update dragonwell Docker tag to v25

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,7 +1,7 @@
 ARG APP_NAME=server
 ARG WORK_HOME=/opt/${APP_NAME}
 
-FROM dragonwell-registry.cn-hangzhou.cr.aliyuncs.com/dragonwell/dragonwell:21-ubuntu AS base
+FROM dragonwell-registry.cn-hangzhou.cr.aliyuncs.com/dragonwell/dragonwell:25-ubuntu AS base
 
 FROM base as build
 ARG WORK_HOME


### PR DESCRIPTION
Manual rebuild of #1054 (closed PR — Renovate does not recreate closed PRs).

## Changes
`server/Dockerfile`: `dragonwell:21-ubuntu` → `dragonwell:25-ubuntu`

## Why manual
#1054 was closed by choice. Renovate's default `recreateWhen: auto` skips closed PRs, and `recreateWhen: always` can't be scoped via `packageRules` (verified in `lib/config/options/index.ts` — no `parents: ['packageRules']`). So a one-shot manual rebuild is the clean way to re-evaluate this major without globally weakening the "close = reject" signal. (Background: #1072 was tried and closed for this reason.)

## ⚠️ Requires verification
Major JDK base image bump (21 → 25). Please verify CI builds and the container runs before merging.