### PR TITLE
chore(renovate): pin typescript to <7 until typescript-eslint supports it

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -27,6 +27,11 @@
       "allowedVersions": "< 2.4.0"
     },
     {
+      "description": "Pin typescript until typescript-eslint supports TS 7 (typescript-eslint/typescript-eslint#10940)",
+      "matchPackageNames": ["typescript"],
+      "allowedVersions": "< 7.0.0"
+    },
+    {
       "description": "Group @ahoo-wang/fetcher ecosystem updates into a single PR",
       "groupName": "ahoo-wang-fetcher",
       "matchPackageNames": ["/^@ahoo-wang\\/fetcher/"]


### PR DESCRIPTION
## Why

Follow-up to #1075 (typescript rollback). Without this pin, Renovate will re-bump `typescript` to v7 on its next run (as it did in #1057), breaking eslint again.

`typescript-eslint` does not support TS 7 yet — [typescript-eslint/typescript-eslint#10940](https://github.com/renovatebot/renovate/issues/10940), blocked on ESLint async parser support. No near-term release.

## Change
Adds a `packageRule` pinning `typescript` to `< 7.0.0`, mirroring the existing Kotlin/KSP pin pattern.

```json
{
  "description": "Pin typescript until typescript-eslint supports TS 7 (...)",
  "matchPackageNames": ["typescript"],
  "allowedVersions": "< 7.0.0"
}
```

## Removal
Delete this rule once `typescript-eslint` ships TS 7 support. The issue link in the description tracks that.