### PR TITLE
ci: add build/test gate (gradle + client)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,11 +64,21 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '24'
-          cache: 'pnpm'
-          cache-dependency-path: client/pnpm-lock.yaml
 
       - name: Set up pnpm
         run: corepack enable && corepack prepare pnpm@9 --activate
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('client/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-
 
       - name: Install dependencies
         run: pnpm install --no-frozen-lockfile

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,80 @@
+name: Build
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - 'document/**'
+  pull_request:
+    paths-ignore:
+      - 'document/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: build-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CI: GITHUB_ACTIONS
+
+jobs:
+  gradle:
+    name: Gradle Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', '**/libs.versions.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Build (compile + test + detekt)
+        run: ./gradlew build --stacktrace
+
+      - name: Coverage verification (domain ≥ 80%)
+        run: ./gradlew :domain:jacocoTestCoverageVerification --stacktrace
+
+  client:
+    name: Client Build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: client
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+          cache-dependency-path: client/pnpm-lock.yaml
+
+      - name: Set up pnpm
+        run: corepack enable && corepack prepare pnpm@9 --activate
+
+      - name: Install dependencies
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Lint (read-only, no --fix)
+        run: pnpm exec eslint .
+
+      - name: Build
+        run: pnpm build


### PR DESCRIPTION
## Why

Adds a GitHub Actions workflow that runs `./gradlew build` and `pnpm lint/build` on push to main and all PRs. Closes the gap that let `typescript@7` break eslint for months with no detection.

## Background

The repo had **no build/test CI gate**. Only:
- `codecov.yml` — runs gradle under coverage-report scope, but `fail_ci_if_error` only gates the Codecov upload, not the build itself
- `renovate.yml`, `gitee-sync.yml` — unrelated

`typescript@7` (auto-bumped by Renovate in #1057) was incompatible with `typescript-eslint`, breaking `eslint .` — but nothing ran client lint, so it merged silently. Fixed retroactively in #1075 (rollback) + #1076 (pin). **This PR prevents recurrence.**

## Jobs (parallel)

**`gradle`** — `ubuntu-latest`, JDK 17 temurin
- `./gradlew build --stacktrace` (compile + test + detekt, with test-retry via `CI=true`)
- `./gradlew :domain:jacocoTestCoverageVerification` (80% coverage gate, separate step for clearer failures)
- Gradle cache via `actions/cache@v4`

**`client`** — `ubuntu-latest`, Node 24 + pnpm 9 (corepack)
- `pnpm install --no-frozen-lockfile` (tolerates Renovate lockfile/package.json desync)
- `pnpm exec eslint .` (**read-only** — the existing `lint` script uses `--fix` which mutates files, inappropriate for CI)
- `pnpm build` (`vite build`)

## Design decisions
- **Independent workflow** (not folded into codecov.yml) — codecov's job is coverage upload; build gating is a separate concern.
- **`pnpm exec eslint .`** instead of `pnpm lint` — avoids `--fix` side effects in CI.
- **No `pnpm test`** — client has zero test files; vitest would green-light nothing.
- **No `pnpm generate`** — requires a running server on :8080, unavailable in CI.
- `actions/checkout@v4` standardizes the inconsistent `@master`/`@v7` across existing workflows.

## Verification plan
- [ ] After merge: `gh workflow run build.yml`, confirm both jobs green
- [ ] Negative test: push a lint error to a throwaway branch, confirm `client` job fails